### PR TITLE
API improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,20 +70,25 @@ const styleQueries = {
   myComponentB: [
     //...
   ],
+
+  componentWithNoConditions: {
+    fontSize: 22,
+  },
 };
 ```
 
 Notice a few different aspects:
 
-- Like with Sass, all the styles for a given component like `myComponentA` are kept in one place. You can see a component's default styles and conditional styles.
+- A style name can have a single object for its styles if it has no conditions. If it has conditions, its value is an array. That array can contain objects for styles that are unconditional. For styles that are conditional, a call to a style query function like `screenWidthMin()` ensures that those styles are only included when conditions are met.
+- As a result, like with Sass, all the styles for a given component like `myComponentA` are kept in one place.
 - Each style object has the structure of a normal React Native style object. We just add additional structure outside of them to add conditional styles.
-- We use helper functions like `screenWidthMin()` to keep the data structure as readable as possible. Under the hood the data could map to something like:
+- Under the hood style query functions could return a structure like:
 
 
 ```js
 const styleQueries = {
   myComponentA: [
-    { fontSize: 12 }, // defaults
+    { fontSize: 12 },
 
     [({screenWidth}) => screenWidth >= 375, {
       fontSize: 16,
@@ -93,29 +98,21 @@ const styleQueries = {
       fontSize: 18,
     }],
   ],
-
-  myComponentA: [
-    { fontSize: 12 }, // defaults
-    // overrides
-  ],
 }
 ```
 
 Note the following:
-- The default styles are a normal React Native style-formatted object.
 - Each conditional set of styles is an array with two elements:
   - The first element is an arrow function that receives attributes of the current device situation, and returns true if this set of styles should be applied. `screenWidth` is the most commonly used for responsive design, but height, dark mode, and other attributes can all be supplied as well. Additional attributes can be added in future versions without breaking the API. And because it's a JavaScript function, logic can be computed however you like.
-  - The second element is a nromal React Native style-formatted object that will be applied if the first element returns true.
+  - The second element is a normal React Native style-formatted object that will be applied if the first element returns true.
 
-So conditional helper functions are just a lightweight wrapper around this data structure to add readability:
+So style query functions are just a lightweight wrapper around this data structure to add readability:
 
 ```js
-function screenWidthMin(minWidth, styles) {
-  return [
-    ({screenWidth}) => screenWidth >= minWidth,
-    styles,
-  ];
-}
+const screenWidthMin = (minimumWidth, conditionalStyles) => {
+  const predicate = ({screenWidth}) => screenWidth >= minimumWidth;
+  return [predicate, conditionalStyles];
+};
 ```
 
 When any device info changes (such as screen dimensions based on device rotation), `useWindowDimensions()` or another relevant hook will rerender, causing the styles to be recomputed.

--- a/src/queries/screenWidthMin.js
+++ b/src/queries/screenWidthMin.js
@@ -1,5 +1,5 @@
-const screenWidthMin = (_, conditionalStyles) => [
-  () => false,
+const screenWidthMin = (minimumWidth, conditionalStyles) => [
+  ({screenWidth}) => screenWidth > minimumWidth,
   conditionalStyles,
 ];
 

--- a/src/queries/screenWidthMin.js
+++ b/src/queries/screenWidthMin.js
@@ -1,6 +1,6 @@
-const screenWidthMin = (minimumWidth, conditionalStyles) => [
-  ({screenWidth}) => screenWidth >= minimumWidth,
-  conditionalStyles,
-];
+const screenWidthMin = (minimumWidth, conditionalStyles) => {
+  const predicate = ({screenWidth}) => screenWidth >= minimumWidth;
+  return [predicate, conditionalStyles];
+};
 
 module.exports = screenWidthMin;

--- a/src/queries/screenWidthMin.js
+++ b/src/queries/screenWidthMin.js
@@ -1,5 +1,5 @@
 const screenWidthMin = (minimumWidth, conditionalStyles) => [
-  ({screenWidth}) => screenWidth > minimumWidth,
+  ({screenWidth}) => screenWidth >= minimumWidth,
   conditionalStyles,
 ];
 

--- a/src/queries/screenWidthMin.js
+++ b/src/queries/screenWidthMin.js
@@ -1,3 +1,6 @@
-const screenWidthMin = (_, conditionalStyles) => [null, conditionalStyles];
+const screenWidthMin = (_, conditionalStyles) => [
+  () => false,
+  conditionalStyles,
+];
 
 module.exports = screenWidthMin;

--- a/src/queries/screenWidthMin.js
+++ b/src/queries/screenWidthMin.js
@@ -1,6 +1,3 @@
-const screenWidthMin = (minWidth, styles) => [
-  ({screenWidth}) => screenWidth >= minWidth,
-  styles,
-];
+const screenWidthMin = (_, conditionalStyles) => [null, conditionalStyles];
 
 module.exports = screenWidthMin;

--- a/src/queries/screenWidthMin.test.js
+++ b/src/queries/screenWidthMin.test.js
@@ -13,6 +13,15 @@ describe('screenWidthMin', () => {
       });
     });
 
+    describe('when screen width is equal to the minimum', () => {
+      it('returns true', () => {
+        const screenWidth = minimumWidth;
+        const [predicate] = screenWidthMin(minimumWidth, {});
+        const returnValue = predicate({screenWidth});
+        expect(returnValue).toEqual(true);
+      });
+    });
+
     describe('when screen width is greater than the minimum', () => {
       it('returns true', () => {
         const screenWidth = minimumWidth + 1;

--- a/src/queries/screenWidthMin.test.js
+++ b/src/queries/screenWidthMin.test.js
@@ -1,6 +1,19 @@
 const screenWidthMin = require('./screenWidthMin');
 
 describe('screenWidthMin', () => {
+  describe('the first element of the returned array, the predicate', () => {
+    const minimumWidth = 375;
+
+    describe('when screen width is less than the minimum', () => {
+      it('returns false', () => {
+        const screenWidth = minimumWidth - 1;
+        const [predicate] = screenWidthMin(minimumWidth, {});
+        const returnValue = predicate({screenWidth});
+        expect(returnValue).toEqual(false);
+      });
+    });
+  });
+
   describe('the second element of the returned array, the conditional styles', () => {
     it('is equal to the passed-in styles', () => {
       const styles = {color: 'green'};

--- a/src/queries/screenWidthMin.test.js
+++ b/src/queries/screenWidthMin.test.js
@@ -12,6 +12,15 @@ describe('screenWidthMin', () => {
         expect(returnValue).toEqual(false);
       });
     });
+
+    describe('when screen width is greater than the minimum', () => {
+      it('returns true', () => {
+        const screenWidth = minimumWidth + 1;
+        const [predicate] = screenWidthMin(minimumWidth, {});
+        const returnValue = predicate({screenWidth});
+        expect(returnValue).toEqual(true);
+      });
+    });
   });
 
   describe('the second element of the returned array, the conditional styles', () => {

--- a/src/queries/screenWidthMin.test.js
+++ b/src/queries/screenWidthMin.test.js
@@ -1,0 +1,11 @@
+const screenWidthMin = require('./screenWidthMin');
+
+describe('screenWidthMin', () => {
+  describe('the second element of the returned array, the conditional styles', () => {
+    it('is equal to the passed-in styles', () => {
+      const styles = {color: 'green'};
+      const [, conditionalStyles] = screenWidthMin(null, styles);
+      expect(conditionalStyles).toEqual(styles);
+    });
+  });
+});

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -5,35 +5,38 @@ function useStyleQueries(styleConfig) {
   const transformedEntries = entries.map(([styleName, styleObjectOrArray]) => {
     let flattenedStyleObject;
     if (Array.isArray(styleObjectOrArray)) {
-      const styleArray = styleObjectOrArray;
-      const reducerInitialValue = {};
-      flattenedStyleObject = styleArray.reduce(
-        (previousValue, currentValue) => {
-          let stylesToMerge = null;
-          if (Array.isArray(currentValue)) {
-            const [predicate, conditionalStyleObject] = currentValue;
-            if (predicate()) {
-              stylesToMerge = conditionalStyleObject;
-            }
-          } else {
-            stylesToMerge = currentValue;
-          }
-
-          if (stylesToMerge) {
-            return {...previousValue, ...stylesToMerge};
-          } else {
-            return previousValue;
-          }
-        },
-        reducerInitialValue
-      );
+      flattenedStyleObject = flattenStyleArray(styleObjectOrArray);
     } else {
-      const styleObject = styleObjectOrArray;
-      flattenedStyleObject = styleObject;
+      flattenedStyleObject = styleObjectOrArray;
     }
     return [styleName, flattenedStyleObject];
   });
   return Object.fromEntries(transformedEntries);
+}
+
+function flattenStyleArray(styleArray) {
+  const reducerInitialValue = {};
+  const flattenedStyleObject = styleArray.reduce(
+    (previousValue, currentValue) => {
+      let stylesToMerge = null;
+      if (Array.isArray(currentValue)) {
+        const [predicate, conditionalStyleObject] = currentValue;
+        if (predicate()) {
+          stylesToMerge = conditionalStyleObject;
+        }
+      } else {
+        stylesToMerge = currentValue;
+      }
+
+      if (stylesToMerge) {
+        return {...previousValue, ...stylesToMerge};
+      } else {
+        return previousValue;
+      }
+    },
+    reducerInitialValue
+  );
+  return flattenedStyleObject;
 }
 
 module.exports = useStyleQueries;

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -11,8 +11,7 @@ function useStyleQueries(styleConfig) {
     }
     return [key, updatedValue];
   });
-  const result = Object.fromEntries(transformedEntries);
-  return result;
+  return Object.fromEntries(transformedEntries);
 }
 
 module.exports = useStyleQueries;

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -2,18 +2,20 @@
 
 function useStyleQueries(styleConfig) {
   const entries = Object.entries(styleConfig);
-  const transformedEntries = entries.map(([key, value]) => {
-    let updatedValue;
-    if (Array.isArray(value)) {
-      if (value.length == 0) {
-        updatedValue = {};
+  const transformedEntries = entries.map(([styleName, styleObjectOrArray]) => {
+    let flattenedStyleObject;
+    if (Array.isArray(styleObjectOrArray)) {
+      const styleArray = styleObjectOrArray;
+      if (styleArray.length == 0) {
+        flattenedStyleObject = {};
       } else {
-        updatedValue = value[0];
+        flattenedStyleObject = styleArray[0];
       }
     } else {
-      updatedValue = value;
+      const styleObject = styleObjectOrArray;
+      flattenedStyleObject = styleObject;
     }
-    return [key, updatedValue];
+    return [styleName, flattenedStyleObject];
   });
   return Object.fromEntries(transformedEntries);
 }

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -9,7 +9,11 @@ function useStyleQueries(styleConfig) {
       const reducerInitialValue = {};
       flattenedStyleObject = styleArray.reduce(
         (previousValue, currentValue) => {
-          return {...previousValue, ...currentValue};
+          if (Array.isArray(currentValue)) {
+            return {};
+          } else {
+            return {...previousValue, ...currentValue};
+          }
         },
         reducerInitialValue
       );

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -6,16 +6,13 @@ function useStyleQueries(styleConfig) {
     let flattenedStyleObject;
     if (Array.isArray(styleObjectOrArray)) {
       const styleArray = styleObjectOrArray;
-      // TODO: set up linter to disallow double-equals
-      if (styleArray.length === 0) {
-        flattenedStyleObject = {};
-      } else {
-        flattenedStyleObject = styleArray.reduce(
-          (previousValue, currentValue) => {
-            return {...previousValue, ...currentValue};
-          }
-        );
-      }
+      const reducerInitialValue = {};
+      flattenedStyleObject = styleArray.reduce(
+        (previousValue, currentValue) => {
+          return {...previousValue, ...currentValue};
+        },
+        reducerInitialValue
+      );
     } else {
       const styleObject = styleObjectOrArray;
       flattenedStyleObject = styleObject;

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -2,7 +2,16 @@
 
 function useStyleQueries(styleConfig) {
   const entries = Object.entries(styleConfig);
-  const result = Object.fromEntries(entries);
+  const transformedEntries = entries.map(([key, value]) => {
+    let updatedValue;
+    if (Array.isArray(value)) {
+      updatedValue = {};
+    } else {
+      updatedValue = value;
+    }
+    return [key, updatedValue];
+  });
+  const result = Object.fromEntries(transformedEntries);
   return result;
 }
 

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -9,15 +9,20 @@ function useStyleQueries(styleConfig) {
       const reducerInitialValue = {};
       flattenedStyleObject = styleArray.reduce(
         (previousValue, currentValue) => {
+          let stylesToMerge = null;
           if (Array.isArray(currentValue)) {
             const [predicate, conditionalStyleObject] = currentValue;
             if (predicate()) {
-              return {...previousValue, ...conditionalStyleObject};
-            } else {
-              return previousValue;
+              stylesToMerge = conditionalStyleObject;
             }
           } else {
-            return {...previousValue, ...currentValue};
+            stylesToMerge = currentValue;
+          }
+
+          if (stylesToMerge) {
+            return {...previousValue, ...stylesToMerge};
+          } else {
+            return previousValue;
           }
         },
         reducerInitialValue

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -10,7 +10,11 @@ function useStyleQueries(styleConfig) {
       if (styleArray.length === 0) {
         flattenedStyleObject = {};
       } else if (styleArray.length > 1) {
-        flattenedStyleObject = {...styleArray[0], ...styleArray[1]};
+        flattenedStyleObject = styleArray.reduce(
+          (previousValue, currentValue) => {
+            return {...previousValue, ...currentValue};
+          }
+        );
       } else {
         flattenedStyleObject = styleArray[0];
       }

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -1,16 +1,21 @@
 // const {useWindowDimensions} = require('react-native');
 
 function useStyleQueries(styleConfig) {
-  const entries = Object.entries(styleConfig);
-  const transformedEntries = entries.map(([styleName, styleObjectOrArray]) => {
-    let flattenedStyleObject;
+  return mapPropertyValues(styleConfig, styleObjectOrArray => {
     if (Array.isArray(styleObjectOrArray)) {
-      flattenedStyleObject = flattenStyleArray(styleObjectOrArray);
+      return flattenStyleArray(styleObjectOrArray);
     } else {
-      flattenedStyleObject = styleObjectOrArray;
+      return styleObjectOrArray;
     }
-    return [styleName, flattenedStyleObject];
   });
+}
+
+function mapPropertyValues(object, mapFunction) {
+  const entries = Object.entries(object);
+  const transformedEntries = entries.map(([key, value]) => [
+    key,
+    mapFunction(value),
+  ]);
   return Object.fromEntries(transformedEntries);
 }
 

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -1,28 +1,7 @@
-const {useWindowDimensions} = require('react-native');
+// const {useWindowDimensions} = require('react-native');
 
-function useStyleQueries(styleConfig) {
-  const {width} = useWindowDimensions();
-  const predicateArgument = {screenWidth: width};
-
-  const styleEntries = Object.entries(styleConfig);
-
-  const styleEntriesToApply = styleEntries.map(([key, styleClauses]) => {
-    // TODO: determine if any entry can be a "defaults" object
-    const styleObject = styleClauses.reduce((acc, clause) => {
-      const [predicate, conditionalStyleObject] = clause;
-
-      const doesClauseMatch = predicate(predicateArgument);
-      if (doesClauseMatch) {
-        return {...acc, ...conditionalStyleObject};
-      } else {
-        return acc;
-      }
-    });
-
-    return [key, styleObject];
-  });
-
-  return Object.fromEntries(styleEntriesToApply);
+function useStyleQueries(/*styleConfig*/) {
+  return {};
 }
 
 module.exports = useStyleQueries;

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -1,7 +1,9 @@
 // const {useWindowDimensions} = require('react-native');
 
 function useStyleQueries(styleConfig) {
-  return styleConfig;
+  const entries = Object.entries(styleConfig);
+  const result = Object.fromEntries(entries);
+  return result;
 }
 
 module.exports = useStyleQueries;

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -9,6 +9,8 @@ function useStyleQueries(styleConfig) {
       // TODO: set up linter to disallow double-equals
       if (styleArray.length === 0) {
         flattenedStyleObject = {};
+      } else if (styleArray.length > 1) {
+        flattenedStyleObject = {...styleArray[0], ...styleArray[1]};
       } else {
         flattenedStyleObject = styleArray[0];
       }

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -1,7 +1,7 @@
 // const {useWindowDimensions} = require('react-native');
 
-function useStyleQueries(/*styleConfig*/) {
-  return {};
+function useStyleQueries(styleConfig) {
+  return styleConfig;
 }
 
 module.exports = useStyleQueries;

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -10,7 +10,12 @@ function useStyleQueries(styleConfig) {
       flattenedStyleObject = styleArray.reduce(
         (previousValue, currentValue) => {
           if (Array.isArray(currentValue)) {
-            return {};
+            const [predicate, conditionalStyleObject] = currentValue;
+            if (predicate()) {
+              return {...previousValue, ...conditionalStyleObject};
+            } else {
+              return previousValue;
+            }
           } else {
             return {...previousValue, ...currentValue};
           }

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -6,7 +6,8 @@ function useStyleQueries(styleConfig) {
     let flattenedStyleObject;
     if (Array.isArray(styleObjectOrArray)) {
       const styleArray = styleObjectOrArray;
-      if (styleArray.length == 0) {
+      // TODO: set up linter to disallow double-equals
+      if (styleArray.length === 0) {
         flattenedStyleObject = {};
       } else {
         flattenedStyleObject = styleArray[0];

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -1,9 +1,12 @@
-// const {useWindowDimensions} = require('react-native');
+const {useWindowDimensions} = require('react-native');
 
 function useStyleQueries(styleConfig) {
+  const {width} = useWindowDimensions();
+  const predicateArgument = {screenWidth: width};
+
   return mapPropertyValues(styleConfig, styleObjectOrArray => {
     if (Array.isArray(styleObjectOrArray)) {
-      return flattenStyleArray(styleObjectOrArray);
+      return flattenStyleArray({styleArray: styleObjectOrArray, predicateArgument});
     } else {
       return styleObjectOrArray;
     }
@@ -19,14 +22,14 @@ function mapPropertyValues(object, mapFunction) {
   return Object.fromEntries(transformedEntries);
 }
 
-function flattenStyleArray(styleArray) {
+function flattenStyleArray({styleArray, predicateArgument}) {
   const reducerInitialValue = {};
   const flattenedStyleObject = styleArray.reduce(
     (previousValue, currentValue) => {
       let stylesToMerge = null;
       if (Array.isArray(currentValue)) {
         const [predicate, conditionalStyleObject] = currentValue;
-        if (predicate()) {
+        if (predicate(predicateArgument)) {
           stylesToMerge = conditionalStyleObject;
         }
       } else {

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -9,14 +9,12 @@ function useStyleQueries(styleConfig) {
       // TODO: set up linter to disallow double-equals
       if (styleArray.length === 0) {
         flattenedStyleObject = {};
-      } else if (styleArray.length > 1) {
+      } else {
         flattenedStyleObject = styleArray.reduce(
           (previousValue, currentValue) => {
             return {...previousValue, ...currentValue};
           }
         );
-      } else {
-        flattenedStyleObject = styleArray[0];
       }
     } else {
       const styleObject = styleObjectOrArray;

--- a/src/useStyleQueries.js
+++ b/src/useStyleQueries.js
@@ -5,7 +5,11 @@ function useStyleQueries(styleConfig) {
   const transformedEntries = entries.map(([key, value]) => {
     let updatedValue;
     if (Array.isArray(value)) {
-      updatedValue = {};
+      if (value.length == 0) {
+        updatedValue = {};
+      } else {
+        updatedValue = value[0];
+      }
     } else {
       updatedValue = value;
     }

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -65,4 +65,28 @@ describe('useStyleQueries', () => {
       });
     });
   });
+
+  describe('when a style array has three style objects', () => {
+    it('returns all style objects merged, with later objects taking precedence', () => {
+      const input = {
+        myComponent: [
+          {
+            color: 'blue',
+            fontFamily: 'Arial',
+            fontSize: 16,
+          },
+          {fontSize: 22},
+          {fontFamily: 'Times New Roman'},
+        ],
+      };
+      const result = useStyleQueries(input);
+      expect(result).toEqual({
+        myComponent: {
+          color: 'blue',
+          fontFamily: 'Times New Roman',
+          fontSize: 22,
+        },
+      });
+    });
+  });
 });

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -102,5 +102,17 @@ describe('useStyleQueries', () => {
         });
       });
     });
+
+    describe('when the condition is true', () => {
+      it("returns the query's style object", () => {
+        const input = {
+          myComponent: [[() => true, {color: 'red'}]],
+        };
+        const result = useStyleQueries(input);
+        expect(result).toEqual({
+          myComponent: {color: 'red'},
+        });
+      });
+    });
   });
 });

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -35,4 +35,16 @@ describe('useStyleQueries', () => {
       });
     });
   });
+
+  describe('when a style array has just one object', () => {
+    it('returns that style object directly', () => {
+      const input = {
+        myComponent: [{fontSize: 16}],
+      };
+      const result = useStyleQueries(input);
+      expect(result).toEqual({
+        myComponent: {fontSize: 16},
+      });
+    });
+  });
 });

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -12,4 +12,15 @@ describe('useStyleQueries', () => {
       expect(styles).toEqual({});
     });
   });
+
+  describe('when a single style object is passed for a style name', () => {
+    it('returns the passed-in style object unchanged', () => {
+      const plainStyles = {
+        myComponentA: {fontSize: 16},
+        myComponentB: {fontSize: 22},
+      };
+      const result = useStyleQueries(plainStyles);
+      expect(result).toEqual(plainStyles);
+    });
+  });
 });

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -1,47 +1,15 @@
 const useStyleQueries = require('./useStyleQueries');
-const {useWindowDimensions} = require('react-native');
+// const {useWindowDimensions} = require('react-native');
 
-jest.mock('react-native', () => ({
-  useWindowDimensions: jest.fn(),
-}));
+// jest.mock('react-native', () => ({
+//   useWindowDimensions: jest.fn(),
+// }));
 
 describe('useStyleQueries', () => {
-  const styleConfig = {
-    text: [
-      {
-        fontFamily: 'Arial',
-        fontSize: 12,
-      },
-      [
-        ({screenWidth}) => screenWidth >= 375,
-        {
-          fontSize: 18,
-          color: 'red',
-        },
-      ],
-    ],
-  };
-
-  it('uses the base styles when no conditions match', () => {
-    useWindowDimensions.mockReturnValue({width: 320});
-    const result = useStyleQueries(styleConfig);
-    expect(result).toEqual({
-      text: {
-        fontFamily: 'Arial',
-        fontSize: 12,
-      },
-    });
-  });
-
-  it('merges conditional styles on top of the base styles', () => {
-    useWindowDimensions.mockReturnValue({width: 375});
-    const result = useStyleQueries(styleConfig);
-    expect(result).toEqual({
-      text: {
-        fontFamily: 'Arial',
-        fontSize: 18,
-        color: 'red',
-      },
+  describe('when no styles are passed', () => {
+    it('returns an empty style object', () => {
+      const styles = useStyleQueries({});
+      expect(styles).toEqual({});
     });
   });
 });

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -89,4 +89,18 @@ describe('useStyleQueries', () => {
       });
     });
   });
+
+  describe('when a style array has one condition', () => {
+    describe('when the condition is false', () => {
+      it('returns an empty style object', () => {
+        const input = {
+          myComponent: [[() => false, {color: 'red'}]],
+        };
+        const result = useStyleQueries(input);
+        expect(result).toEqual({
+          myComponent: {},
+        });
+      });
+    });
+  });
 });

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -142,5 +142,67 @@ describe('useStyleQueries', () => {
     });
   });
 
+  describe('when a style array has two conditions', () => {
+    describe('when neither condition is true', () => {
+      it('returns an empty style object', () => {
+        const input = {
+          myComponent: [
+            [() => false, {color: 'darkRed'}],
+            [() => false, {color: 'red'}],
+          ],
+        };
+        const result = useStyleQueries(input);
+        expect(result).toEqual({
+          myComponent: {},
+        });
+      });
+    });
+
+    describe('when only the first condition is true', () => {
+      it("returns the first condition's style", () => {
+        const input = {
+          myComponent: [
+            [() => true, {color: 'green'}],
+            [() => false, {color: 'red'}],
+          ],
+        };
+        const result = useStyleQueries(input);
+        expect(result).toEqual({
+          myComponent: {color: 'green'},
+        });
+      });
+    });
+
+    describe('when only the second condition is true', () => {
+      it("returns the second condition's style", () => {
+        const input = {
+          myComponent: [
+            [() => false, {color: 'red'}],
+            [() => true, {color: 'green'}],
+          ],
+        };
+        const result = useStyleQueries(input);
+        expect(result).toEqual({
+          myComponent: {color: 'green'},
+        });
+      });
+    });
+
+    describe('when both conditions are true', () => {
+      it("merges the conditions' styles", () => {
+        const input = {
+          myComponent: [
+            [() => true, {color: 'green', fontSize: 16}],
+            [() => true, {fontSize: 22}],
+          ],
+        };
+        const result = useStyleQueries(input);
+        expect(result).toEqual({
+          myComponent: {color: 'green', fontSize: 22},
+        });
+      });
+    });
+  });
+
   test.todo('arguments to conditional function, starting with window width');
 });

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -116,5 +116,31 @@ describe('useStyleQueries', () => {
     });
   });
 
+  describe('when a style array has an object followed by a condition', () => {
+    describe('when the condition is false', () => {
+      it('returns the style object', () => {
+        const input = {
+          myComponent: [{color: 'green'}, [() => false, {color: 'red'}]],
+        };
+        const result = useStyleQueries(input);
+        expect(result).toEqual({
+          myComponent: {color: 'green'},
+        });
+      });
+    });
+
+    describe('when the condition is true', () => {
+      it('merges the conditional styles into the object', () => {
+        const input = {
+          myComponent: [{color: 'red'}, [() => true, {color: 'green'}]],
+        };
+        const result = useStyleQueries(input);
+        expect(result).toEqual({
+          myComponent: {color: 'green'},
+        });
+      });
+    });
+  });
+
   test.todo('arguments to conditional function, starting with window width');
 });

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -202,6 +202,29 @@ describe('useStyleQueries', () => {
         });
       });
     });
+
+    describe('when a style array has a mix of objects and conditions', () => {
+      it('merges all objects and true conditions', () => {
+        const input = {
+          myComponent: [
+            [() => true, {color: 'yellow', fontFamily: 'Arial', fontSize: 16}],
+            {fontSize: 22},
+            [() => false, {color: 'red'}],
+            [() => true, {fontFamily: 'Times New Roman'}],
+            {color: 'green'},
+            [() => false, {fontFamily: 'Papyrus'}],
+          ],
+        };
+        const result = useStyleQueries(input);
+        expect(result).toEqual({
+          myComponent: {
+            color: 'green',
+            fontFamily: 'Times New Roman',
+            fontSize: 22,
+          },
+        });
+      });
+    });
   });
 
   test.todo('arguments to conditional function, starting with window width');

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -47,4 +47,22 @@ describe('useStyleQueries', () => {
       });
     });
   });
+
+  describe('when a style array has two style objects', () => {
+    it('returns the style objects merged, with later objects taking precedence', () => {
+      const input = {
+        myComponent: [
+          {
+            color: 'blue',
+            fontSize: 16,
+          },
+          {fontSize: 22},
+        ],
+      };
+      const result = useStyleQueries(input);
+      expect(result).toEqual({
+        myComponent: {color: 'blue', fontSize: 22},
+      });
+    });
+  });
 });

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -115,4 +115,6 @@ describe('useStyleQueries', () => {
       });
     });
   });
+
+  test.todo('arguments to conditional function, starting with window width');
 });

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -1,11 +1,17 @@
 const useStyleQueries = require('./useStyleQueries');
-// const {useWindowDimensions} = require('react-native');
+const {useWindowDimensions} = require('react-native');
 
-// jest.mock('react-native', () => ({
-//   useWindowDimensions: jest.fn(),
-// }));
+jest.mock('react-native', () => ({
+  useWindowDimensions: jest.fn(),
+}));
 
 describe('useStyleQueries', () => {
+  const screenWidth = 375;
+
+  beforeEach(() => {
+    useWindowDimensions.mockReturnValue({width: screenWidth});
+  });
+
   describe('when no styles are passed', () => {
     it('returns an empty style object', () => {
       const styles = useStyleQueries({});
@@ -91,6 +97,14 @@ describe('useStyleQueries', () => {
   });
 
   describe('when a style array has one condition', () => {
+    it('passes the screen width into the predicate function', () => {
+      const predicate = args => expect(args.screenWidth).toEqual(screenWidth);
+      const input = {
+        myComponent: [[predicate, {}]],
+      };
+      useStyleQueries(input);
+    });
+
     describe('when the condition is false', () => {
       it('returns an empty style object', () => {
         const input = {

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -23,4 +23,16 @@ describe('useStyleQueries', () => {
       expect(result).toEqual(plainStyles);
     });
   });
+
+  xdescribe('when an empty array is passed for a style name', () => {
+    it('returns an empty style object', () => {
+      const input = {
+        myComponentA: [],
+      };
+      const result = useStyleQueries(input);
+      expect(result).toEqual({
+        myComponentA: {},
+      });
+    });
+  });
 });

--- a/src/useStyleQueries.test.js
+++ b/src/useStyleQueries.test.js
@@ -24,7 +24,7 @@ describe('useStyleQueries', () => {
     });
   });
 
-  xdescribe('when an empty array is passed for a style name', () => {
+  describe('when an empty array is passed for a style name', () => {
     it('returns an empty style object', () => {
       const input = {
         myComponentA: [],


### PR DESCRIPTION
- Allow passing just a style object for a style instead of an array. This allows intermixing conditional and unconditional styles, so that you don't have to separate out the unconditional ones to a normal `StyleSheet`
- Within the style array, allows either conditional or unconditional styles at any element of the array. This makes the array act more predictably, rather than having to explain rules like "the first element must be unconditional styles, and all other elements must be conditional"
- Rewrote `useStyleQueries()` with TDD to ensure thorough test coverage of edge cases